### PR TITLE
fix(zsh): use $HOME instead of hardcoded username in ZSH path

### DIFF
--- a/zshell/.zshrc
+++ b/zshell/.zshrc
@@ -17,7 +17,7 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
 fi
 
 # Oh-My-Zsh Configuration
-export ZSH="/Users/hannadrehman/.oh-my-zsh"
+export ZSH="$HOME/.oh-my-zsh"
 ZSH_DISABLE_COMPFIX=true
 ZSH_THEME="powerlevel10k/powerlevel10k"
 


### PR DESCRIPTION
## Summary
- `export ZSH` was hardcoded to `/Users/hannadrehman/.oh-my-zsh` which doesn't exist on this machine
- Oh My Zsh silently failed to load, so `ZSH_THEME="powerlevel10k/powerlevel10k"` was never applied
- Changed to `$HOME/.oh-my-zsh` so it works regardless of username

## Root cause
A previous commit (`fd8fa07`) removed the direct `source /opt/homebrew/share/powerlevel10k/powerlevel10k.zsh-theme` fallback that had been masking the broken path. Once that line was gone, the hardcoded stale path was fully exposed and the p10k theme stopped loading.